### PR TITLE
Code Refactoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,36 +45,11 @@ repos:
     rev: "v20.1.5"
     hooks:
       - id: clang-format
-  # ESLint for linting JavaScript and TypeScript files
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: "v9.27.0"
-    hooks:
-      - id: eslint
   # Runs mypy to check Python type annotations.
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.15.0"
     hooks:
       - id: mypy
-  # Lints SCSS files to enforce style and best practices.
-  - repo: https://github.com/pre-commit/mirrors-scss-lint
-    rev: "v0.60.0"
-    hooks:
-      - id: scss-lint
-  # Runs JSHint to analyze JavaScript code for potential errors.
-  - repo: https://github.com/pre-commit/mirrors-jshint
-    rev: "v2.13.6"
-    hooks:
-      - id: jshint
-  # Uses fixmyjs to automatically fix simple JavaScript issues.
-  - repo: https://github.com/pre-commit/mirrors-fixmyjs
-    rev: "v2.0.0"
-    hooks:
-      - id: fixmyjs
-  # Runs CSSLint to check CSS files for errors and stylistic issues.
-  - repo: https://github.com/pre-commit/mirrors-csslint
-    rev: "v1.0.5"
-    hooks:
-      - id: csslint
   # ShellCheck hook for linting shell scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.10.0.1"
@@ -112,23 +87,6 @@ repos:
     rev: "0.2.2"
     hooks:
       - id: checkmake
-  # SQLFluff for linting and fixing SQL files
-  - repo: https://github.com/sqlfluff/sqlfluff
-    rev: "3.4.0"
-    hooks:
-      - id: sqlfluff-lint
-      - id: sqlfluff-fix
-  # RuboCop for linting Ruby files
-  - repo: https://github.com/rubocop/rubocop
-    rev: "v1.75.7"
-    hooks:
-      - id: rubocop
-  # Terraform-py for formatting and validating Terraform files
-  - repo: https://github.com/AleksaC/terraform-py
-    rev: "v1.12.1"
-    hooks:
-      - id: tf-fmt
-      - id: tf-validate
   # Gitleaks for detecting secrets in Git repositories
   - repo: https://github.com/gitleaks/gitleaks
     rev: "v8.26.0"


### PR DESCRIPTION
This pull request updates the `.pre-commit-config.yaml` file by removing several pre-commit hooks that are no longer in use. The changes primarily focus on streamlining the configuration by eliminating hooks for linting and formatting various file types.

### Removed pre-commit hooks:

#### JavaScript, CSS, and SCSS linting:
* Removed hooks for `eslint`, `jshint`, `fixmyjs`, and `csslint`, which were used for linting and fixing JavaScript and CSS files.

#### SQL, Ruby, and Terraform linting:
* Removed hooks for `sqlfluff`, `rubocop`, and `terraform-py`, which were used for linting and validating SQL, Ruby, and Terraform files.