### PR TITLE
Fix Liscense Type

### DIFF
--- a/design_patterns/creational/singleton/singleton.hpp
+++ b/design_patterns/creational/singleton/singleton.hpp
@@ -15,7 +15,7 @@
  * License
  **************************************************************************************/
 /*
- * This file is licensed under the MIT License.
+ * This file is licensed under the Apache 2.0 License.
  * License information should be updated as necessary.
  */
 
@@ -41,7 +41,7 @@
  **************************************************************************************/
 
 /*
- * EagerSingleton class
+ * EagerSingleton Class
  * This class implements the Singleton design pattern using eager
  * initialization. It ensures that only one instance of the class is created at
  * program startup, and provides a global point of access to that instance.
@@ -68,7 +68,7 @@ class EagerSingleton {
 };
 
 /*
- * LazySingleton class
+ * LazySingleton Class
  * This class implements the Singleton design pattern using lazy initialization.
  * It ensures that only one instance of the class is created and provides a
  * global point of access to that instance.
@@ -100,7 +100,7 @@ class LazySingleton {
 };
 
 /*
- * ThreadSafeSingleton class
+ * ThreadSafeSingleton Class
  * This class implements the Singleton design pattern with thread safety.
  * It ensures that only one instance of the class is created, even in a
  * multithreaded environment.

--- a/snippets/c_cpp.code-snippets
+++ b/snippets/c_cpp.code-snippets
@@ -31,7 +31,7 @@
       " * License",
       " **************************************************************************************/",
       "/*",
-      " * This file is licensed under the MIT License.",
+      " * This file is licensed under the Apache 2.0 License.",
       " * License information should be updated as necessary.",
       " */",
       "",


### PR DESCRIPTION
This pull request updates licensing information and standardizes class naming conventions in the Singleton design pattern implementation. The most important changes include switching the license from MIT to Apache 2.0 and ensuring consistent capitalization in class names.

### Licensing updates:
* Changed the license from MIT to Apache 2.0 in `design_patterns/creational/singleton/singleton.hpp`.
* Updated license information in `snippets/c_cpp.code-snippets` to reflect the switch to Apache 2.0.

### Naming conventions:
* Standardized class names in `design_patterns/creational/singleton/singleton.hpp` by capitalizing "Class" in comments for `EagerSingleton`, `LazySingleton`, and `ThreadSafeSingleton`. [[1]](diffhunk://#diff-96ff7e30061e8de7779683d163c92943e3837e55f2bfcb4c82c7a193b56930efL44-R44) [[2]](diffhunk://#diff-96ff7e30061e8de7779683d163c92943e3837e55f2bfcb4c82c7a193b56930efL71-R71) [[3]](diffhunk://#diff-96ff7e30061e8de7779683d163c92943e3837e55f2bfcb4c82c7a193b56930efL103-R103)