### PR TITLE
Fix Jekyll Site

### DIFF
--- a/design_patterns/_config.yml
+++ b/design_patterns/_config.yml
@@ -1,0 +1,11 @@
+plugins:
+  - jekyll-relative-links
+relative_links:
+  enabled: true
+  collections: true
+exclude:
+  - *.cpp
+  - *.h
+  - *.hpp
+  - *.c++
+  - *.cc


### PR DESCRIPTION
This pull request introduces a configuration update to the `design_patterns/_config.yml` file to enhance the handling of relative links in the Jekyll site. The change enables the `jekyll-relative-links` plugin and configures it to work with collections while excluding specific file types.

Configuration changes:

* [`design_patterns/_config.yml`](diffhunk://#diff-f18de481aa893eca62a09539b74795b60bd6c8a8741867b2fbe66f42f80391a3R1-R11): Added the `jekyll-relative-links` plugin with settings to enable relative links for collections and exclude certain file extensions (`*.cpp`, `*.h`, `*.hpp`, `*.c++`, `*.cc`).