### PR TITLE
Added automatically generate index.md

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -25,6 +25,26 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Generate index.md for internal folders
+        run: |
+          find design_patterns -type d | while read dir; do
+            if [ ! -f "$dir/index.md" ] && [ "$dir" != "design_patterns" ]; then
+              echo "---" > "$dir/index.md"
+              echo "title: Index of $dir" >> "$dir/index.md"
+              echo "layout: default" >> "$dir/index.md"
+              echo "---" >> "$dir/index.md"
+              echo "# Index of $dir" >> "$dir/index.md"
+              echo "" >> "$dir/index.md"
+              for f in "$dir"/*; do
+                fname=$(basename "$f")
+                if [ -d "$f" ]; then
+                  echo "- 📁 [$fname]($fname/index.md)" >> "$dir/index.md"
+                elif [ -f "$f" ] && [ "$fname" != "index.md" ]; then
+                  echo "- 📄 [$fname]($fname)" >> "$dir/index.md"
+                fi
+              done
+            fi
+          done
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:


### PR DESCRIPTION
This pull request adds functionality to automatically generate `index.md` files for internal folders within the `design_patterns` directory in the GitHub Pages workflow. This ensures that each folder has an index file with links to its subfolders and files for better navigation.

Enhancements to GitHub Pages workflow:

* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3R28-R47): Added a step to generate `index.md` files for internal folders in the `design_patterns` directory. This step creates an index file with a title, layout, and links to subfolders and files, improving the organization and accessibility of content.