### PR TITLE
Fixing Github Pages Order

### DIFF
--- a/design_patterns/_config.yml
+++ b/design_patterns/_config.yml
@@ -1,3 +1,7 @@
+remote_theme: jekyll/minima
+title: ""
+description: "A comprehensive guide to design patterns, best practices, and real-world examples."
+author: "@gvatsal60"
 exclude:
   - "*.cpp"
   - "*.h"

--- a/design_patterns/behavioral/index.md
+++ b/design_patterns/behavioral/index.md
@@ -5,17 +5,17 @@ Explore each pattern below for clear explanations and practical code samples:
 
 ---
 
-- 🔗 [**Chain of Responsibility**](chain_of_responsibility)
-- 📝 [**Command**](command)
-- 🗣️ [**Interpreter**](interpreter)
-- 🔄 [**Iterator**](iterator)
-- 🕹️ [**Mediator**](mediator)
-- 🗃️ [**Memento**](memento)
-- 👀 [**Observer**](observer)
-- 🌀 [**State**](state)
-- 🧠 [**Strategy**](strategy)
-- 🏗️ [**Template Method**](template_method)
-- 🧳 [**Visitor**](visitor)
+- 🔗 [**Chain of Responsibility**](chain_of_responsibility/)
+- 📝 [**Command**](command/)
+- 🗣️ [**Interpreter**](interpreter/)
+- 🔄 [**Iterator**](iterator/)
+- 🕹️ [**Mediator**](mediator/)
+- 🗃️ [**Memento**](memento/)
+- 👀 [**Observer**](observer/)
+- 🌀 [**State**](state/)
+- 🧠 [**Strategy**](strategy/)
+- 🏗️ [**Template Method**](template_method/)
+- 🧳 [**Visitor**](visitor/)
 
 ---
 

--- a/design_patterns/creational/index.md
+++ b/design_patterns/creational/index.md
@@ -5,11 +5,11 @@ Explore each pattern below for concise explanations and practical code samples:
 
 ---
 
-- 🏭 [**Abstract Factory**](abstract_factory)
-- 👷 [**Builder**](builder)
-- 🧩 [**Factory Method**](factory_method)
-- 🧙 [**Prototype**](prototype)
-- 🔒 [**Singleton**](singleton)
+- 🏭 [**Abstract Factory**](abstract_factory/)
+- 👷 [**Builder**](builder/)
+- 🧩 [**Factory Method**](factory_method/)
+- 🧙 [**Prototype**](prototype/)
+- 🔒 [**Singleton**](singleton/)
 
 ---
 

--- a/design_patterns/creational/singleton/index.md
+++ b/design_patterns/creational/singleton/index.md
@@ -41,6 +41,3 @@ Thread-Safe Singleton instance address: 0x55f8c8e2c320
 ```
 
 ## References
-
-- [singleton header](singleton.hpp)
-- [singleton implementation](singleton.cpp)

--- a/design_patterns/structural/index.md
+++ b/design_patterns/structural/index.md
@@ -5,13 +5,13 @@ Explore each pattern below for clear explanations and practical code samples:
 
 ---
 
-- 🧩 [**Adapter**](adapter)
-- 🏰 [**Bridge**](bridge)
-- 🖼️ [**Composite**](composite)
-- 🏞️ [**Decorator**](decorator)
-- 🏢 [**Facade**](facade)
-- 🧵 [**Flyweight**](flyweight)
-- 🔗 [**Proxy**](proxy)
+- 🧩 [**Adapter**](adapter/)
+- 🏰 [**Bridge**](bridge/)
+- 🖼️ [**Composite**](composite/)
+- 🏞️ [**Decorator**](decorator/)
+- 🏢 [**Facade**](facade/)
+- 🧵 [**Flyweight**](flyweight/)
+- 🔗 [**Proxy**](proxy/)
 
 ---
 


### PR DESCRIPTION
This pull request introduces improvements to the `design_patterns` project, including updates to the site configuration, adjustments to link formatting across multiple index files, and removal of outdated references. The most significant changes focus on enhancing the project's organization and usability.

### Site Configuration Update:
* [`design_patterns/_config.yml`](diffhunk://#diff-f18de481aa893eca62a09539b74795b60bd6c8a8741867b2fbe66f42f80391a3R1-R4): Added a remote theme (`jekyll/minima`), updated the title and description, and specified the author to improve the site's metadata and appearance.

### Link Formatting Adjustments:
* [`design_patterns/behavioral/index.md`](diffhunk://#diff-a8abfdc001a87a2f52639794f10c7ff4eb43b484dd064e4c4c38a9a2f400d89dL8-R18): Updated links to include trailing slashes for better compatibility with static site generators.
* [`design_patterns/creational/index.md`](diffhunk://#diff-e838ba2e44df9661c0d8a89ad4aa59b08e2dbc3b6c9fb2870a0a33efcc30b760L8-R12): Updated links to include trailing slashes for consistency and improved navigation.
* [`design_patterns/structural/index.md`](diffhunk://#diff-6c15312729f0fd2540524f807f24b24114ec55967b3cf3274e75f7fa32a588a5L8-R14): Adjusted links to include trailing slashes for uniformity across the project.

### Removal of Outdated References:
* [`design_patterns/creational/singleton/index.md`](diffhunk://#diff-ee51a839618b55d2ab484b0ddfd811c7572a6d9b496346175155c65240c8e1f3L44-L46): Removed references to `singleton.hpp` and `singleton.cpp` files, which appear to be outdated or unnecessary.