### PR TITLE
Fix Github Pages

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -2,9 +2,8 @@
 name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 on:
   # Runs on pushes targeting the default branch
-  pull_request:
-  # push:
-  #   branches: ["master"]
+  push:
+    branches: ["master"]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
This pull request updates the deployment workflow and modifies the configuration of the design patterns documentation. The most important changes include switching the workflow trigger from `push` to `pull_request` and removing the `remote_theme` configuration.

Workflow updates:

* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3L5-R7): Changed the workflow trigger from `push` targeting the `master` branch to `pull_request`, enabling the workflow to run on pull requests instead.

Configuration changes:

* [`design_patterns/_config.yml`](diffhunk://#diff-f18de481aa893eca62a09539b74795b60bd6c8a8741867b2fbe66f42f80391a3L1): Removed the `remote_theme` configuration, which previously referenced `jekyll/minima`.