### PR TITLE
Removed Automatic index.md creation

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -25,26 +25,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Generate index.md for internal folders
-        run: |
-          find design_patterns -type d | while read dir; do
-            if [ ! -f "$dir/index.md" ] && [ "$dir" != "design_patterns" ]; then
-              echo "---" > "$dir/index.md"
-              echo "title: Index of $dir" >> "$dir/index.md"
-              echo "layout: default" >> "$dir/index.md"
-              echo "---" >> "$dir/index.md"
-              echo "# Index of $dir" >> "$dir/index.md"
-              echo "" >> "$dir/index.md"
-              for f in "$dir"/*; do
-                fname=$(basename "$f")
-                if [ -d "$f" ]; then
-                  echo "- 📁 [$fname]($fname/index.md)" >> "$dir/index.md"
-                elif [ -f "$f" ] && [ "$fname" != "index.md" ]; then
-                  echo "- 📄 [$fname]($fname)" >> "$dir/index.md"
-                fi
-              done
-            fi
-          done
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:


### PR DESCRIPTION
This pull request removes a step from the GitHub Actions workflow for building Jekyll pages. The removed step previously generated `index.md` files for internal folders in the `design_patterns` directory.

### Workflow simplification:
* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3L28-L47): Removed the step that dynamically created `index.md` files for subdirectories within the `design_patterns` folder. This step included generating metadata and links to files and subfolders within each directory.[Copilot is generating a summary...]