### PR TITLE
Reverted Jekyll Config

### DIFF
--- a/design_patterns/_config.yml
+++ b/design_patterns/_config.yml
@@ -2,7 +2,7 @@
 title: ""
 description: "A comprehensive guide to design patterns, best practices, and real-world examples."
 author: "@gvatsal60"
-baseurl: "design_patterns" # Leave as '/' unless you're deploying in a sub-folder
+# baseurl: "design_patterns" # Leave as '/' unless you're deploying in a sub-folder
 # Exclude files
 exclude:
   - "*.cpp"
@@ -15,11 +15,7 @@ plugins:
   - jekyll-relative-links
   - jekyll-seo-tag
   - jekyll-sitemap
-  - jekyll-feed
 # Relative links configuration
 relative_links:
   enabled: true
   collections: true
-# Footer
-footer:
-  text: "A comprehensive guide to design patterns, best practices, and real-world examples."


### PR DESCRIPTION
This pull request makes adjustments to the `design_patterns/_config.yml` file to streamline configuration and remove unnecessary elements. The changes primarily involve commenting out or removing unused settings and plugins.

Configuration cleanup:

* Commented out the `baseurl` setting to simplify deployment configuration. (`[design_patterns/_config.ymlL5-R5](diffhunk://#diff-f18de481aa893eca62a09539b74795b60bd6c8a8741867b2fbe66f42f80391a3L5-R5)`)
* Removed the `jekyll-feed` plugin from the `plugins` section, as it is no longer required. (`[design_patterns/_config.ymlL18-L25](diffhunk://#diff-f18de481aa893eca62a09539b74795b60bd6c8a8741867b2fbe66f42f80391a3L18-L25)`)
* Deleted the `footer` configuration block, which included redundant text already present in the `description`. (`[design_patterns/_config.ymlL18-L25](diffhunk://#diff-f18de481aa893eca62a09539b74795b60bd6c8a8741867b2fbe66f42f80391a3L18-L25)`)