### PR TITLE
Fix Container Things

### DIFF
--- a/.clang-format.yaml
+++ b/.clang-format.yaml
@@ -1,7 +1,7 @@
 Language: Cpp
-BasedOnStyle: Google
+# BasedOnStyle:  Google
 AccessModifierOffset: -1
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: DontAlign
 AlignArrayOfStructures: None
 AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
@@ -11,11 +11,11 @@ AlignEscapedNewlines: Left
 AlignOperands: Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: None
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
@@ -26,7 +26,7 @@ AlwaysBreakTemplateDeclarations: Yes
 AttributeMacros:
   - __capability
 BinPackArguments: true
-BinPackParameters: true
+BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false
@@ -56,8 +56,8 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit: 80
-CommentPragmas: "^ IWYU pragma:"
+ColumnLimit: 120
+CommentPragmas: '^ IWYU pragma:'
 QualifierAlignment: Leave
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
@@ -70,6 +70,7 @@ EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 PackConstructorInitializers: NextLine
+BasedOnStyle: ''
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
@@ -89,16 +90,16 @@ IncludeCategories:
     Priority: 1
     SortPriority: 0
     CaseSensitive: false
-  - Regex: "^<.*"
+  - Regex: '^<.*'
     Priority: 2
     SortPriority: 0
     CaseSensitive: false
-  - Regex: ".*"
+  - Regex: '.*'
     Priority: 3
     SortPriority: 0
     CaseSensitive: false
-IncludeIsMainRegex: "([-_](test|unittest))?$"
-IncludeIsMainSourceRegex: ""
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
 IndentCaseLabels: true
 IndentCaseBlocks: false
@@ -113,8 +114,8 @@ JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 LambdaBodyIndentation: Signature
-MacroBlockBegin: ""
-MacroBlockEnd: ""
+MacroBlockBegin: ''
+MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Never
@@ -142,9 +143,9 @@ RawStringFormats:
       - cpp
       - Cpp
       - CPP
-      - "c++"
-      - "C++"
-    CanonicalDelimiter: ""
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
     BasedOnStyle: google
   - Language: TextProto
     Delimiters:
@@ -220,6 +221,3 @@ WhitespaceSensitiveMacros:
   - BOOST_PP_STRINGIZE
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
----
-Language: Json
-BasedOnStyle: Google

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,13 +6,13 @@
     "vscode": {
       "extensions": [
         "DavidAnson.vscode-markdownlint",
-        "MindpathTechnologyLimited.code-error-lens",
         "Tyriar.sort-lines",
         "bradzacher.vscode-copy-filename",
         "foxundermoon.shell-format",
+        "llvm-vs-code-extensions.vscode-clangd",
         "ms-azuretools.vscode-docker",
-        "ms-vscode.cpptools",
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        "usernamehw.errorlens"
       ],
       "settings": {
         "[cpp]": {


### PR DESCRIPTION
This pull request primarily updates the code style configuration by renaming and extensively modifying the `.clang-format` file (now `.clang-format.yaml`), and makes adjustments to the recommended VS Code extensions in `.devcontainer/devcontainer.json`. The changes focus on customizing C++ formatting rules for increased readability and consistency, and improving the development environment setup.

### Code Style Configuration Updates

* Renamed `.clang-format` to `.clang-format.yaml` and overhauled formatting options, including switching `AlignAfterOpenBracket` to `DontAlign`, disabling bin packing for parameters, and increasing the `ColumnLimit` from 80 to 120 characters for improved code readability. [[1]](diffhunk://#diff-f429010d6e2b2bd2627aad39d957409d137b6ae98a8c8baf22ac98343dbd5fd4L2-R4) [[2]](diffhunk://#diff-f429010d6e2b2bd2627aad39d957409d137b6ae98a8c8baf22ac98343dbd5fd4L29-R29) [[3]](diffhunk://#diff-f429010d6e2b2bd2627aad39d957409d137b6ae98a8c8baf22ac98343dbd5fd4L59-R60)
* Changed several formatting preferences, such as disallowing all parameters of a declaration on the next line, restricting short functions on a single line, and updating brace wrapping and indentation rules for more consistent code structure. [[1]](diffhunk://#diff-f429010d6e2b2bd2627aad39d957409d137b6ae98a8c8baf22ac98343dbd5fd4L14-R18) [[2]](diffhunk://#diff-f429010d6e2b2bd2627aad39d957409d137b6ae98a8c8baf22ac98343dbd5fd4R73)
* Updated quoting conventions and regex patterns to use single quotes for consistency, and standardized raw string format delimiters and macro block settings. [[1]](diffhunk://#diff-f429010d6e2b2bd2627aad39d957409d137b6ae98a8c8baf22ac98343dbd5fd4L92-R102) [[2]](diffhunk://#diff-f429010d6e2b2bd2627aad39d957409d137b6ae98a8c8baf22ac98343dbd5fd4L116-R118) [[3]](diffhunk://#diff-f429010d6e2b2bd2627aad39d957409d137b6ae98a8c8baf22ac98343dbd5fd4L145-R148)
* Removed the legacy JSON formatting section from the end of the configuration file, indicating a focus solely on C++ formatting rules.

### Development Environment Improvements

* Updated the list of recommended VS Code extensions in `.devcontainer/devcontainer.json`: replaced `MindpathTechnologyLimited.code-error-lens` with `usernamehw.errorlens`, added `llvm-vs-code-extensions.vscode-clangd`, and reordered some extensions to better support C++ development workflows.