### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
       ],
       "settings": {
         "[cpp]": {
-          "editor.defaultFormatter": "ms-vscode.cpptools"
+          "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
         },
         "[markdown]": {
           "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"


### PR DESCRIPTION
This pull request makes a minor update to the default C++ code formatter in the devcontainer configuration.

* Changed the C++ formatter in `.devcontainer/devcontainer.json` from `ms-vscode.cpptools` to `llvm-vs-code-extensions.vscode-clangd` for improved formatting consistency.