### PR TITLE
Fix Sonar

### DIFF
--- a/design_patterns/creational/singleton/singleton.hpp
+++ b/design_patterns/creational/singleton/singleton.hpp
@@ -83,8 +83,7 @@ public:
   // Static method to access the `singleton` instance
   static const LazySingleton &getInstance() { // Lazy initialization
     if (instance == nullptr) {
-      // Constructor is private, so std::make_unique can't be used. Safe to use
-      // new here. NOSONAR
+      // NOSONAR: Constructor is private, so std::make_unique can't be used. Safe to use new here.
       instance = std::unique_ptr<LazySingleton>(new LazySingleton());
     }
 
@@ -115,8 +114,7 @@ public:
   static const ThreadSafeSingleton &getInstance() {
     // Use std::call_once to ensure that the instance is created only once
     std::call_once(initFlag, []() {
-      // Constructor is private, so std::make_unique can't be used. Safe to use
-      // new here. NOSONAR
+      // NOSONAR: Constructor is private, so std::make_unique can't be used. Safe to use new here.
       instance =
           std::unique_ptr<ThreadSafeSingleton>(new ThreadSafeSingleton());
     });


### PR DESCRIPTION
This pull request makes a minor documentation update to the comments in the singleton implementation. The change clarifies the rationale for using `new` by moving the `NOSONAR` annotation to the beginning of the comment, improving its visibility and intent.